### PR TITLE
Text changes to better show app's purpose

### DIFF
--- a/FingerprintProDemo/Features/Home/View/DeviceFingerprintView.swift
+++ b/FingerprintProDemo/Features/Home/View/DeviceFingerprintView.swift
@@ -69,8 +69,8 @@ private extension DeviceFingerprintView {
     var signupView: some View {
         CallToActionView(
             title: "Impressed with Fingerprint?",
-            description: "Try free for 14 days, credit card not needed.",
-            primaryButtonTitle: "Sign up",
+            description: "Check our website for more info.",
+            primaryButtonTitle: "Learn more",
             primaryAction: {
                 openURL(C.URLs.signUp)
             },

--- a/FingerprintProDemo/Features/Home/View/HomeView.swift
+++ b/FingerprintProDemo/Features/Home/View/HomeView.swift
@@ -81,7 +81,7 @@ private extension HomeView {
                 Link(destination: C.URLs.support) {
                     Label("Support", systemImage: "message")
                 }
-                Link("Sign Up", destination: C.URLs.signUp)
+                Link("Learn more", destination: C.URLs.signUp)
             } label: {
                 Label("More", systemImage: "ellipsis.circle")
             }

--- a/FingerprintProDemo/Resources/Localizable.xcstrings
+++ b/FingerprintProDemo/Resources/Localizable.xcstrings
@@ -81,6 +81,16 @@
         }
       }
     },
+    "Check our website for more info." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check our website for more info."
+          }
+        }
+      }
+    },
     "CONFIDENCE" : {
       "localizations" : {
         "en" : {
@@ -351,8 +361,25 @@
         }
       }
     },
+    "Learn more" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Learn more"
+          }
+        }
+      }
+    },
     "MITM ATTACK" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MITM ATTACK"
+          }
+        }
+      }
     },
     "More" : {
       "localizations" : {
@@ -584,26 +611,6 @@
         }
       }
     },
-    "Sign up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign up"
-          }
-        }
-      }
-    },
-    "Sign Up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Up"
-          }
-        }
-      }
-    },
     "Signal disabled for your app" : {
       "localizations" : {
         "en" : {
@@ -645,7 +652,14 @@
       }
     },
     "TAMPERED REQUEST" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TAMPERED REQUEST"
+          }
+        }
+      }
     },
     "Tap to begin" : {
       "localizations" : {
@@ -743,16 +757,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Try again"
-          }
-        }
-      }
-    },
-    "Try free for 14 days, credit card not needed." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try free for 14 days, credit card not needed."
           }
         }
       }

--- a/FingerprintProDemo/UI/Views/CallToActionView.swift
+++ b/FingerprintProDemo/UI/Views/CallToActionView.swift
@@ -104,9 +104,9 @@ struct CallToActionView: View {
             stringLiteral: "Impressed with Fingerprint?"
         ),
         description: AttributedString(
-            stringLiteral: "Try free for 14 days, credit card not needed."
+            stringLiteral: "Check our website for more info."
         ),
-        primaryButtonTitle: "Sign up",
+        primaryButtonTitle: "Learn more",
         primaryAction: {
             print("primaryAction()")
         },

--- a/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
@@ -423,9 +423,9 @@ private extension EventDetailsView {
                         stringLiteral: "Impressed with Fingerprint?"
                     ),
                     description: AttributedString(
-                        stringLiteral: "Try free for 14 days, credit card not needed."
+                        stringLiteral: "Check our website for more info."
                     ),
-                    primaryButtonTitle: "Sign up",
+                    primaryButtonTitle: "Learn more",
                     primaryAction: { print("primaryAction()") },
                     secondaryButtonTitle: "Don’t show again for a week",
                     secondaryAction: { print("secondaryAction()") }


### PR DESCRIPTION
# Purpose
There are multiple changes needed for the app store to better show the purpose of our demo application.

- Changed "Sign up" to "Learn more" across the app to better represent button's purpose;
- Changed sign up text to "check our website" to better represent the meaning of CTAs.