### PR TITLE
Add Location Tracking and permission collection from the latest SDK

### DIFF
--- a/FingerprintProDemo/Domain/Services/DeviceIdentification/DeviceIdentificationService.swift
+++ b/FingerprintProDemo/Domain/Services/DeviceIdentification/DeviceIdentificationService.swift
@@ -8,6 +8,7 @@ protocol FingerprintClientFactory {
 
 protocol DeviceIdentificationServiceProtocol: Sendable {
     func fingerprintDevice() async throws -> FingerprintResponse
+    func startCollectingLocation() async throws
 }
 
 struct DeviceIdentificationService<ClientFactory: FingerprintClientFactory>: DeviceIdentificationServiceProtocol {
@@ -17,9 +18,19 @@ struct DeviceIdentificationService<ClientFactory: FingerprintClientFactory>: Dev
     init(settingsContainer: any ReadOnlySettingsContainer) {
         self.settingsContainer = settingsContainer
     }
+    
+    func startCollectingLocation() async throws {
+        let client = try makeFingerprintClient()
+        await MainActor.run {
+            client.allowUseOfLocationData = true
+        }
+    }
 
     func fingerprintDevice() async throws -> FingerprintResponse {
         let client = try makeFingerprintClient()
+        await MainActor.run {
+            client.allowUseOfLocationData = true
+        }
         let response = try await client.getVisitorIdResponse()
         return response
     }

--- a/FingerprintProDemo/Domain/Services/Geolocation/GeolocationService+Default.swift
+++ b/FingerprintProDemo/Domain/Services/Geolocation/GeolocationService+Default.swift
@@ -1,8 +1,10 @@
+@MainActor
 extension GeolocationService {
 
-    static let shared: GeolocationService = .init()
+    static let shared: GeolocationService = .init(identificationService: .default)
 }
 
+@MainActor
 extension GeolocationServiceProtocol where Self == GeolocationService {
 
     static var `default`: Self { .shared }

--- a/FingerprintProDemo/Domain/Services/Geolocation/GeolocationService.swift
+++ b/FingerprintProDemo/Domain/Services/Geolocation/GeolocationService.swift
@@ -1,4 +1,5 @@
 @preconcurrency import CoreLocation
+import FingerprintPro
 import os
 
 protocol GeolocationServiceProtocol: Sendable {
@@ -21,23 +22,49 @@ final class GeolocationService: NSObject, GeolocationServiceProtocol {
         initialState: .notDetermined
     )
 
-    private let locationManager = CLLocationManager()
-    private let shouldRequestPermission: Bool
+    private let locationHelper: LocationPermissionHelperProviding
+    private let identificationService: any DeviceIdentificationServiceProtocol
 
-    init(shouldRequestPermission: Bool = true) {
-        self.shouldRequestPermission = shouldRequestPermission
+    @MainActor
+    init(identificationService: any DeviceIdentificationServiceProtocol) {
+        self.locationHelper = FingerprintProFactory.getLocationPermissionHelperInstance()
+        self.identificationService = identificationService
         super.init()
-        locationManager.delegate = self
+        self.locationHelper.delegate = self
     }
 }
 
-extension GeolocationService: CLLocationManagerDelegate {
+extension GeolocationService: LocationPermissionDelegate {
 
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        currentAuthorizationStatus.withLock { status in
-            status = manager.authorizationStatus
-            guard status == .notDetermined, shouldRequestPermission else { return }
-            manager.requestWhenInUseAuthorization()
+    func locationPermissionHelper(
+        _ helper: LocationPermissionHelperProviding,
+        shouldShowLocationRationale rationale: LocationPermissionRationale
+    ) {
+        os_log("Location rationale: %{public}@", String(describing: rationale))
+
+        switch rationale {
+        case .needInitialPermission:
+            helper.requestPermission()
+        case .upgradeToPrecise:
+            helper.requestTemporaryPrecisePermission()
+        case .needSettingsChange:
+            helper.requestTemporaryPrecisePermission()
+        @unknown default:
+            os_log("⚠️ Received unknown rationale: %{public}@", String(describing: rationale))
+        }
+    }
+
+    func locationPermissionHelper(
+        _ helper: LocationPermissionHelperProviding,
+        didUpdateLocationPermission status: CLAuthorizationStatus
+    ) {
+        currentAuthorizationStatus.withLock { $0 = status }
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            Task {
+                try? await identificationService.startCollectingLocation()
+            }
+        default: break
         }
     }
 }

--- a/FingerprintProDemo/Features/Home/ViewModel/DeviceFingerprintViewModel.swift
+++ b/FingerprintProDemo/Features/Home/ViewModel/DeviceFingerprintViewModel.swift
@@ -22,11 +22,12 @@ final class DeviceFingerprintViewModel: ObservableObject {
     private nonisolated let geolocationService: any GeolocationServiceProtocol
     private nonisolated let settingsContainer: SettingsContainer
 
+    @MainActor
     init(
-        identificationService: any DeviceIdentificationServiceProtocol = .default,
-        smartSignalsService: (any SmartSignalsServiceProtocol)? = .default,
-        geolocationService: any GeolocationServiceProtocol = .default,
-        settingsContainer: SettingsContainer = .default
+        identificationService: any DeviceIdentificationServiceProtocol,
+        smartSignalsService: (any SmartSignalsServiceProtocol)?,
+        geolocationService: any GeolocationServiceProtocol,
+        settingsContainer: SettingsContainer
     ) {
         self.identificationService = identificationService
         self.smartSignalsService = smartSignalsService

--- a/FingerprintProDemo/Features/RootView.swift
+++ b/FingerprintProDemo/Features/RootView.swift
@@ -8,11 +8,18 @@ extension RootView where Home == HomeView, Settings == SettingsView {
             deviceFingerprintViewModel: {
                 guard ConfigVariable.SmartSignals.isEnabled else {
                     return .init(
+                        identificationService: .default,
                         smartSignalsService: .none,
-                        geolocationService: GeolocationService(shouldRequestPermission: false)
+                        geolocationService: .default,
+                        settingsContainer: .default
                     )
                 }
-                return .init()
+                return .init(
+                    identificationService: .default,
+                    smartSignalsService: .none,
+                    geolocationService: .default,
+                    settingsContainer: .default
+                )
             }()
         )
         settings = .init(

--- a/FingerprintProDemo/PreviewContent/DeviceIdentificationService+Preview.swift
+++ b/FingerprintProDemo/PreviewContent/DeviceIdentificationService+Preview.swift
@@ -2,6 +2,7 @@ import FingerprintPro
 
 struct DeviceIdentificationServicePreviewFixture: DeviceIdentificationServiceProtocol {
 
+    func startCollectingLocation() async throws {}
     func fingerprintDevice() async throws -> FingerprintResponse { .preview }
 }
 


### PR DESCRIPTION
# Purpose
Add support for latest version of SDK with i32 signal and Location Permission collection
- Refactored `GeolocationService` to use `LocationPermissionHelper`
- Added `startCollectingLocation` functionality from the latest SDK version
