### PR TITLE
Add button to send user's API response to support email.

### DIFF
--- a/FingerprintProDemo/Features/Settings/View/CustomApiKeysView.swift
+++ b/FingerprintProDemo/Features/Settings/View/CustomApiKeysView.swift
@@ -57,15 +57,13 @@ private extension CustomApiKeysView {
     var headerSection: some View {
         section(
             description: """
-                When enabled, the app will use your API keys to make all the requests. \
-                These requests will count towards your monthly allowance.
+                When enabled, the app will use your API keys to make requests through your service account. By default, the app is configured with a PRO API key for initial access. Need help? Contact our support team at [fingerprint.com/support](\(C.URLs.support, format: .url))
                 """,
             header: {
                 Text(
                     AttributedString(
                         localized: """
-                            You can obtain API keys by logging in to \
-                            [fingerprint.com](\(C.URLs.signIn, format: .url)).
+                            API key is tied to your service account. It does not unlock any paid features.
                             """
                     )
                 )

--- a/FingerprintProDemo/Resources/Localizable.xcstrings
+++ b/FingerprintProDemo/Resources/Localizable.xcstrings
@@ -81,6 +81,9 @@
         }
       }
     },
+    "Attach Raw Response to Email" : {
+
+    },
     "Check our website for more info." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -745,6 +748,9 @@
         }
       }
     },
+    "This key enables basic connectivity with our service. It does not unlock paid features." : {
+
+    },
     "Too many requests" : {
       "localizations" : {
         "en" : {
@@ -806,6 +812,7 @@
       }
     },
     "When enabled, the app will use your API keys to make all the requests. These requests will count towards your monthly allowance." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -814,6 +821,9 @@
           }
         }
       }
+    },
+    "When enabled, the app will use your API keys to make requests through your service account. By default, the app is configured with a PRO API key for initial access. Need help? Contact our support team at [fingerprint.com/support](%@)" : {
+
     },
     "Write a Review" : {
       "localizations" : {
@@ -836,6 +846,7 @@
       }
     },
     "You can obtain API keys by logging in to [fingerprint.com](%@)." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
@@ -120,6 +120,28 @@ private extension EventDetailsView {
             .pickerStyle(.segmented)
             .disabled(isLoading)
 
+            if case let .presenting(_, rawDetailsText) = state {
+                HStack {
+                    Button {
+                        sendSupportEmail(with: rawDetailsText)
+                    } label: {
+                        Label("Attach Raw Response to Email", systemImage: "envelope")
+                            .font(.inter(size: 14.0))
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.accentColor.opacity(0.1))
+                            )
+                    }
+                    .foregroundStyle(.accent)
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8.0)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+
             switch detailsDisplayMode {
             case .prettified:
                 prettifiedDetails
@@ -291,6 +313,22 @@ private extension EventDetailsView {
                 badge: presentation.badge(for: key)
             )
         }
+    }
+
+    func sendSupportEmail(with rawDetails: String) {
+        let subject = "Raw Response Debug Info"
+        let body = """
+                Hello,
+
+                Please find the raw response below:
+
+                \(rawDetails)
+            """
+        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let mailtoURL = URL(string: "mailto:support@fingerprint.com?subject=\(encodedSubject)&body=\(encodedBody)")!
+
+        UIApplication.shared.open(mailtoURL)
     }
 
     struct PrettifiedItem: Identifiable {


### PR DESCRIPTION
# Purpose
To pass App Store review it was decided to change couple labels and to add oportunity to send API response to our support email.

- Added button to send raw API response to support email
- Changed labels on API Key page