### PR TITLE
Remove API key functionality

### DIFF
--- a/FingerprintProDemo/Features/Settings/View/SettingsView.swift
+++ b/FingerprintProDemo/Features/Settings/View/SettingsView.swift
@@ -22,7 +22,6 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack(path: $navigationPath) {
             List {
-                requestSection
                 otherSection
             }
             .background(.backgroundGray)


### PR DESCRIPTION
# Purpose
Remove API key functionality from settings.

- Removed Requests section from the Settings page

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-16 at 10 37 25" src="https://github.com/user-attachments/assets/18f02ac5-97e6-4da7-a5cc-1d2f8e2f53f8" />
