### PR TITLE
Fix JSON escaping in raw response

### DIFF
--- a/FingerprintProDemo/Features/Home/ViewModel/ClientResponseEventViewModel.swift
+++ b/FingerprintProDemo/Features/Home/ViewModel/ClientResponseEventViewModel.swift
@@ -28,7 +28,7 @@ extension ClientResponseEventViewModel {
     var rawEventRepresentation: String {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601Full
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
 
         guard
             let jsonData = try? encoder.encode(event),
@@ -139,7 +139,11 @@ private extension ClientResponseEventViewModel {
         guard vpn.data.result else {
             return LocalizedStrings.notDetected.rawValue
         }
-        return .init(localized: "Device time zone is \(vpn.data.originTimezone)")
+        if vpn.data.methods.auxiliaryMobile {
+            return .init(localized: "Device has VPN enabled")
+        } else {
+            return .init(localized: "VPN usage suspected, device timezone is \(vpn.data.originTimezone)")
+        }
     }
 
     var factoryResetItemValue: AttributedString {

--- a/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
@@ -355,8 +355,9 @@ private extension EventDetailsView {
                 Group {
                     title
                     Text(item.value)
-                        .font(.inter(size: 14.0))
+                        .font(.system(size: 14))
                         .kerning(0.14)
+                        .textSelection(.enabled)
                         .foregroundStyle(item.valueForeground)
                         .background(item.valueBackground)
                         .cornerRadius(4.0)


### PR DESCRIPTION
# Purpose
There are instances of "\/" in raw JSON response as Swift misinterprets these character combinations
- Added replacement of problematic character combination
