### PR TITLE
Change `visitor id` and `request id` value fonts to monospaced

### DIFF
--- a/FingerprintProDemo/Resources/Localizable.xcstrings
+++ b/FingerprintProDemo/Resources/Localizable.xcstrings
@@ -42,7 +42,14 @@
       }
     },
     "API key is tied to your service account. It does not unlock any paid features." : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API key is tied to your service account. It does not unlock any paid features."
+          }
+        }
+      }
     },
     "API Keys" : {
       "localizations" : {
@@ -85,15 +92,11 @@
       }
     },
     "Attach Raw Response to Email" : {
-
-    },
-    "Check our website for more info." : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Check our website for more info."
+            "value" : "Attach Raw Response to Email"
           }
         }
       }
@@ -138,22 +141,22 @@
         }
       }
     },
+    "Device has VPN enabled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device has VPN enabled"
+          }
+        }
+      }
+    },
     "Device intelligence powered by\nFingerprint iOS SDK %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Device intelligence powered by\nFingerprint iOS SDK %@"
-          }
-        }
-      }
-    },
-    "Device time zone is %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device time zone is %@"
           }
         }
       }
@@ -174,17 +177,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Documentation"
-          }
-        }
-      }
-    },
-    "Don’t show again for a week" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don’t show again for a week"
           }
         }
       }
@@ -319,17 +311,6 @@
         }
       }
     },
-    "Impressed with Fingerprint?" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impressed with Fingerprint?"
-          }
-        }
-      }
-    },
     "Invalid keys!" : {
       "localizations" : {
         "en" : {
@@ -366,17 +347,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JAILBREAK"
-          }
-        }
-      }
-    },
-    "Learn more" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Learn more"
           }
         }
       }
@@ -811,19 +781,25 @@
         }
       }
     },
-    "When enabled, the app will use your API keys to make all the requests. These requests will count towards your monthly allowance." : {
-      "extractionState" : "stale",
+    "VPN usage suspected, device timezone is %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "When enabled, the app will use your API keys to make all the requests. These requests will count towards your monthly allowance."
+            "value" : "VPN usage suspected, device timezone is %@"
           }
         }
       }
     },
     "When enabled, the app will use your API keys to make requests through your service account. By default, the app is configured with a PRO API key for initial access. Need help? Contact our support team at [fingerprint.com/support](%@)" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, the app will use your API keys to make requests through your service account. By default, the app is configured with a PRO API key for initial access. Need help? Contact our support team at [fingerprint.com/support](%@)"
+          }
+        }
+      }
     },
     "Write a Review" : {
       "localizations" : {
@@ -841,17 +817,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yes"
-          }
-        }
-      }
-    },
-    "You can obtain API keys by logging in to [fingerprint.com](%@)." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can obtain API keys by logging in to [fingerprint.com](%@)."
           }
         }
       }

--- a/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/EventDetailsView.swift
@@ -84,7 +84,7 @@ private extension EventDetailsView {
                     .foregroundStyle(.gray400)
 
                 Text(foremostItemValue)
-                    .font(.inter(size: 22.0, weight: .medium))
+                    .font(.system(size: 22, design: .monospaced))
                     .foregroundStyle(isPresenting ? .accent : .clear)
                     .background(isPresenting ? .clear : .gray100)
                     .cornerRadius(4.0)
@@ -312,6 +312,7 @@ private extension EventDetailsView {
                 value: value,
                 valueForeground: valueForeground,
                 valueBackground: valueBackground,
+                valueFontDesign: presentation.valueFontDesign(for: key),
                 badge: presentation.badge(for: key)
             )
         }
@@ -339,6 +340,7 @@ private extension EventDetailsView {
         let value: AttributedString
         let valueForeground: Color
         let valueBackground: Color
+        let valueFontDesign: Font.Design
         let badge: Badge?
     }
 
@@ -355,7 +357,7 @@ private extension EventDetailsView {
                 Group {
                     title
                     Text(item.value)
-                        .font(.system(size: 14))
+                        .font(.system(size: 14, design: item.valueFontDesign))
                         .kerning(0.14)
                         .textSelection(.enabled)
                         .foregroundStyle(item.valueForeground)

--- a/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/BasicResponseEventPresentability.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/BasicResponseEventPresentability.swift
@@ -59,4 +59,11 @@ struct BasicResponseEventPresentability: ClientResponseEventPresentability {
         case .vpn: .placeholder(length: 32)
         }
     }
+
+    func valueFontDesign(for key: ItemKey) -> Font.Design {
+        switch key {
+        case .visitorId, .requestId: .monospaced
+        default: .default
+        }
+    }
 }

--- a/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/EventPresentability.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/EventPresentability.swift
@@ -21,6 +21,7 @@ protocol EventPresentability {
 
     func badge(for key: ItemKey) -> Badge?
     func valuePlaceholder(for key: ItemKey) -> String
+    func valueFontDesign(for key: ItemKey) -> Font.Design
 }
 
 extension EventPresentability {
@@ -33,4 +34,5 @@ extension EventPresentability {
     var emptyValueString: AttributedString? { .none }
 
     func badge(for key: ItemKey) -> Badge? { .none }
+    func valueFontDesign(for key: ItemKey) -> Font.Design { .default }
 }

--- a/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/ExtendedResponseEventPresentability.swift
+++ b/FingerprintProDemo/UI/Views/EventDetailsView/Presentation/ExtendedResponseEventPresentability.swift
@@ -64,4 +64,11 @@ struct ExtendedResponseEventPresentability: ClientResponseEventPresentability {
         case .vpn: .placeholder(length: 32)
         }
     }
+
+    func valueFontDesign(for key: ItemKey) -> Font.Design {
+        switch key {
+        case .visitorId, .requestId: .monospaced
+        default: .default
+        }
+    }
 }


### PR DESCRIPTION
# Purpose
Make identification request results more readable
- Changes `visitor id` and `request id` value fonts to monospaced.
- Fixes and removes unused localizable strings.