### PR TITLE
Bump Xcode version to 16.1 for E2E tests workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - "15.4"  # Swift 5.10
+          - "16.1"  # Swift 6.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Purpose
- Bumps Xcode version to 16.1 for E2E tests workflow.