### PR TITLE
Improve E2E tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,11 +19,11 @@ jobs:
       id-token: 'write'
       contents: 'read'
       repository-projects: read
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         xcode:
-          - "16.1"  # Swift 6.0
+          - "16.4"  # Swift 6.1
 
     steps:
       - name: Checkout

--- a/FingerprintProDemo.xctestplan
+++ b/FingerprintProDemo.xctestplan
@@ -27,7 +27,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:FingerprintProDemo.xcodeproj",
         "identifier" : "AD04EEED2E2CF128005E7046",

--- a/FingerprintProDemoUITests/FingerprintProDemoUITests.swift
+++ b/FingerprintProDemoUITests/FingerprintProDemoUITests.swift
@@ -13,14 +13,15 @@ final class FingerprintProDemoUITests: XCTestCase {
         static let fingerprintResultView = "fingerprintResultView"
     }
 
-    private let tapToBeginTimeout: TimeInterval = 10
-    private let fingerprintViewTimeout: TimeInterval = 20
+    private let tapToBeginTimeout: TimeInterval = 20
+    private let fingerprintViewTimeout: TimeInterval = 30
 
     private var sut: XCUIApplication!
 
     override func setUp() {
         super.setUp()
         sut = XCUIApplication()
+        setUpAutoDismissAlert()
     }
 
     func test_givenNoKey_whenFingeprintViewDisplayed_thenShowsKeyMissingOrInvalidError() {
@@ -86,6 +87,22 @@ final class FingerprintProDemoUITests: XCTestCase {
 }
 
 private extension FingerprintProDemoUITests {
+
+    func setUpAutoDismissAlert() {
+        addUIInterruptionMonitor(withDescription: "Location Permission Alert") { alert in
+            let dontAllowButton = alert.buttons["Don't Allow"]
+            if dontAllowButton.exists {
+                dontAllowButton.tap()
+                return true
+            }
+            let cancelButton = alert.buttons["Cancel"]
+            if cancelButton.exists {
+                cancelButton.tap()
+                return true
+            }
+            return false
+        }
+    }
 
     func captureTestScreenshot() {
         add(sut.screenshotAttachment())

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -7,11 +7,16 @@ readonly SCRIPT_ABS_PATH="$(cd "$(dirname "$0")" &>/dev/null && pwd -P)"
 readonly XCODE_PROJECT="$SCRIPT_ABS_PATH/../FingerprintProDemo.xcodeproj"
 readonly XCODE_SCHEME="FingerprintProDemo"
 
-readonly PLATFORM_IOS="iOS Simulator,name=iPhone 16 Pro"
+readonly SIMULATOR="iPhone 16 Pro"
+readonly PLATFORM_IOS="iOS Simulator,name=$SIMULATOR"
 
 readonly RESULTS_BUNDLE="E2ETestResults"
 
 rm -rf "${RESULTS_BUNDLE}" "${RESULTS_BUNDLE}.xcresult"
+
+# Boot simulator before `xcodebuild` command to avoid exit code 65
+# in GitHub Workflow when `xcodebuild` would start the simulator to run tests.
+xcrun simctl boot "$SIMULATOR"
 
 xcodebuild clean test \
     -project "$XCODE_PROJECT" \


### PR DESCRIPTION
# Purpose
Improves E2E tests with several adjustments to better suit GitHub workflow.
- Hides location permission alert
- Increases timeouts
- Disables tests parallelization
- Boots simulator before tests are run to prevent exit code 65 with E2E tests workflow
- Bumps Xcode version to 16.4 for E2E tests workflow